### PR TITLE
Updated Compile.php to prevent mixin being created more than once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "SC7639/jade.php",
+    "name": "sc7639/jade.php",
     "version": "1.0.0",
     "description": "HAML-like template engine for PHP 5.3",
     "keywords": ["jade", "minification","template"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jumplink/jade.php",
+    "name": "SC7639/jade.php",
     "version": "1.0.0",
     "description": "HAML-like template engine for PHP 5.3",
     "keywords": ["jade", "minification","template"],
@@ -8,17 +8,10 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Andreas Nurbo",
-            "email": "muss@ausgefuelltsein.de",
-            "homepage": "http://cyonitesystems.com",
+            "name": "Scott Crossan",
+            "email": "scrott@gmail.com",
             "role": "Maintainer"
         },
-	{
-	    "name": "Pascal Garber",
-            "email": "pascal@jumplink.eu",
-            "homepage": "https://jumplink.eu",
-            "role": "Bugfixes"
-	}
     ],
     "require": {
         "php": ">=5.3.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "name": "Scott Crossan",
             "email": "scrott@gmail.com",
             "role": "Maintainer"
-        },
+        }
     ],
     "require": {
         "php": ">=5.3.0"

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -14,6 +14,7 @@ class Compiler
     protected $terse        = false;
     protected $withinCase   = false;
     protected $indents      = 0;
+    protected $mixins       = array();
 
     protected $doctypes = array(
         '5'             => '<!DOCTYPE html>',
@@ -670,22 +671,26 @@ class Compiler
             $this->buffer($code);
 
         } else {
-            if ($arguments === null || empty($arguments)) {
-                $arguments = array();
-            } else
-            if (!is_array($arguments)) {
-                $arguments = array($arguments);
+            if(!in_array($name, $this->mixins)) {
+                $this->mixins[] = $name;
+
+                if ($arguments === null || empty($arguments)) {
+                    $arguments = array();
+                } else
+                if (!is_array($arguments)) {
+                    $arguments = array($arguments);
+                }
+
+                //TODO: assign nulls to all varargs for remove php warnings
+                array_unshift($arguments, 'attributes');
+                $code = $this->createCode("function {$name} (%s) {", implode(',',$arguments));
+
+                $this->buffer($code);
+                $this->indents++;
+                $this->visit($block);
+                $this->indents--;
+                $this->buffer($this->createCode('}'));
             }
-
-            //TODO: assign nulls to all varargs for remove php warnings
-            array_unshift($arguments, 'attributes');
-            $code = $this->createCode("function {$name} (%s) {", implode(',',$arguments));
-
-            $this->buffer($code);
-            $this->indents++;
-            $this->visit($block);
-            $this->indents--;
-            $this->buffer($this->createCode('}'));
         }
     }
 

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -841,7 +841,7 @@ class Compiler
                     } else {
 
                         //новый код для isset
-                        if(!preg_match('/[&|^\(\)]/',$code)){
+                        if(!preg_match('/[&|^\(\)]/',$code) && !preg_match('/[=*]/', $code)){
                             $conditional = sprintf($conditional, $matches[1], 'isset(%s) && %s');
                             $this->buffer($this->createCode($conditional, $code, $code));
                         }else{

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -31,7 +31,7 @@ class Compiler
 
     protected $selfClosing  = array('meta', 'img', 'link', 'input', 'source', 'area', 'base', 'col', 'br', 'hr');
     protected $phpKeywords  = array('true','false','null','switch','case','default','endswitch','if','elseif','else','endif','while','endwhile','do','foreach','endforeach','for','endfor','as','unless');
-    protected $phpOpenBlock = array('switch','if','elseif','else','while','do','foreach','for','unless');
+    protected $phpOpenBlock = array('switch','if', 'else if', 'elseif','else','while','do','foreach','for','unless');
     protected $phpCloseBlock= array('endswitch','endif','endwhile','endforeach','endfor');
 
     public function __construct($prettyprint=false)

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -938,7 +938,7 @@ class Compiler
                     if ($key == 'class') {
                         $value = $this->createCode('echo (is_array(%1$s)) ? implode(" ", %1$s) : %1$s', $value);
                     } elseif (strpos($key, 'data-') !== false) {
-                        $value = $this->createCode('echo json_encode(%s)', $value);
+                        $value = $this->createCode('echo (is_array(%1$s) ? htmlentities(json_encode(%1$s)) : %1$s)', $value);
                     } else {
                         $value = $this->createCode('echo %s', $value);
                     }


### PR DESCRIPTION
When extending a jade file that includes another jade file that includes a mixin, the mixin is created twice once at the top of the page and in the html section that is being included.

I've added an new array property mixins to the Compiler.php file and added a check before creating the mixin as a function if the mixin's name isn't in the array then add the name to the array and create the array in the interpolated HTML.
